### PR TITLE
Feat: Create New Board and Dynamic Board Rendering

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8,6 +8,8 @@
       "name": "client",
       "version": "0.0.0",
       "dependencies": {
+        "@fortawesome/free-solid-svg-icons": "^6.4.2",
+        "@fortawesome/react-fontawesome": "^0.2.0",
         "axios": "^1.5.0",
         "localforage": "^1.10.0",
         "match-sorter": "^6.3.1",
@@ -808,6 +810,52 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-common-types": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-6.4.2.tgz",
+      "integrity": "sha512-1DgP7f+XQIJbLFCTX1V2QnxVmpLdKdzzo2k8EmvDOePfchaIGQ9eCHj2up3/jNEbZuBqel5OxiaOJf37TWauRA==",
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/fontawesome-svg-core": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.2.tgz",
+      "integrity": "sha512-gjYDSKv3TrM2sLTOKBc5rH9ckje8Wrwgx1CxAPbN5N3Fm4prfi7NsJVWd1jklp7i5uSCVwhZS5qlhMXqLrpAIg==",
+      "hasInstallScript": true,
+      "peer": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/free-solid-svg-icons": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-6.4.2.tgz",
+      "integrity": "sha512-sYwXurXUEQS32fZz9hVCUUv/xu49PEJEyUOsA51l6PU/qVgfbTb2glsTEaJngVVT8VqBATRIdh7XVgV1JF1LkA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@fortawesome/fontawesome-common-types": "6.4.2"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@fortawesome/react-fontawesome": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.2.0.tgz",
+      "integrity": "sha512-uHg75Rb/XORTtVt7OS9WoK8uM276Ufi7gCzshVWkUJbHhh3svsUUeqXerrM96Wm7fRiDzfKRwSoahhMIkGAYHw==",
+      "dependencies": {
+        "prop-types": "^15.8.1"
+      },
+      "peerDependencies": {
+        "@fortawesome/fontawesome-svg-core": "~1 || ~6",
+        "react": ">=16.3"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2879,7 +2927,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3129,7 +3176,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -3196,8 +3242,7 @@
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",

--- a/client/package.json
+++ b/client/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@fortawesome/free-solid-svg-icons": "^6.4.2",
+    "@fortawesome/react-fontawesome": "^0.2.0",
     "axios": "^1.5.0",
     "localforage": "^1.10.0",
     "match-sorter": "^6.3.1",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -3,6 +3,7 @@ import Root from './components/Root';
 import HomePage from './pages/HomePage';
 import AuthPage from './pages/AuthPage';
 import BoardPage from './pages/BoardPage';
+import Board from './components/Board';
 import LogoutPage from './pages/LogoutPage';
 import './App.css';
 
@@ -15,6 +16,7 @@ const router = createBrowserRouter([
       { path: 'login', element: <AuthPage /> },
       { path: 'signup', element: <AuthPage /> },
       { path: 'board', element: <BoardPage /> },
+      { path: 'board/:id', element: <Board /> },
       { path: 'logout', element: <LogoutPage /> },
     ],
   },

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -1,5 +1,5 @@
 import { useContext } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { Context } from '../context/Context';
 import MenuModal from './MenuModal';
 import BoardDetailsModal from './BoardDetailsModal';
@@ -7,13 +7,22 @@ import BoardDetailsModal from './BoardDetailsModal';
 export default function Board() {
   const { boards, displayMenuModal, boardDetails } = useContext(Context);
   const { id } = useParams();
-  const { pathname } = useLocation();
 
   const board = boards?.find(board => board._id === id);
 
   return (
     <main>
-      <h1>{pathname === '/board' ? boards[0]?.name : board.name}</h1>
+      {board && (
+        <>
+          <h1>{board.name}</h1>
+
+          <section>
+            {board.columns.map(column => (
+              <span>{column}()</span>
+            ))}
+          </section>
+        </>
+      )}
 
       {displayMenuModal && <MenuModal />}
       {boardDetails && <BoardDetailsModal />}

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -1,0 +1,22 @@
+import { useContext } from 'react';
+import { useLocation, useParams } from 'react-router-dom';
+import { Context } from '../context/Context';
+import MenuModal from './MenuModal';
+import BoardDetailsModal from './BoardDetailsModal';
+
+export default function Board() {
+  const { boards, displayMenuModal, boardDetails } = useContext(Context);
+  const { id } = useParams();
+  const { pathname } = useLocation();
+
+  const board = boards?.find(board => board._id === id);
+
+  return (
+    <main>
+      <h1>{pathname === '/board' ? boards[0]?.name : board.name}</h1>
+
+      {displayMenuModal && <MenuModal />}
+      {boardDetails && <BoardDetailsModal />}
+    </main>
+  );
+}

--- a/client/src/components/BoardDetailsModal.jsx
+++ b/client/src/components/BoardDetailsModal.jsx
@@ -1,11 +1,73 @@
+import { useState, useContext } from 'react';
+import { Context } from '../context/Context';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default function BoardDetailsModal({ boardDetails, setBoardDetails }) {
+export default function BoardDetailsModal() {
+  const { boardDetails, setBoardDetails } = useContext(Context);
+
+  const [boardColumns, setBoardColumns] = useState([
+    { id: 0, columnName: 'Todo' },
+    { id: 1, columnName: 'Doing' },
+  ]);
+
+  function addNewColumn() {
+    const newColumn = {
+      id: boardColumns.length,
+      columnName: '',
+    };
+
+    setBoardColumns([...boardColumns, newColumn]);
+  }
+
+  function updateColumnName(id, key, value) {
+    setBoardColumns(
+      boardColumns.map(column => {
+        if (column.id === id) {
+          return {
+            ...column,
+            [key]: value,
+          };
+        } else {
+          return column;
+        }
+      })
+    );
+  }
+
   return (
     <div>
       <FontAwesomeIcon icon={faXmark} onClick={() => setBoardDetails(null)} />
       <h2>{boardDetails === 'new' ? 'Add New' : 'Edit'} Board</h2>
+
+      <form action="/board/createBoard" method="POST">
+        <label>
+          Board Name{' '}
+          <input type="text" name="boardName" placeholder="e.g. Web Design" />
+        </label>
+
+        <label>
+          Board Columns
+          {boardColumns.map(column => (
+            <input
+              key={column.id}
+              type="text"
+              name="columnName"
+              value={column.columnName}
+              onChange={e =>
+                updateColumnName(column.id, 'columnName', e.target.value)
+              }
+            />
+          ))}
+        </label>
+
+        <button type="button" onClick={addNewColumn}>
+          + Add New Column
+        </button>
+        <button type="submit">
+          {boardDetails === 'new' ? 'Create New Board' : 'Save Changes'}
+        </button>
+      </form>
     </div>
   );
 }

--- a/client/src/components/BoardDetailsModal.jsx
+++ b/client/src/components/BoardDetailsModal.jsx
@@ -1,0 +1,11 @@
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+
+export default function BoardDetailsModal({ boardDetails, setBoardDetails }) {
+  return (
+    <div>
+      <FontAwesomeIcon icon={faXmark} onClick={() => setBoardDetails(null)} />
+      <h2>{boardDetails === 'new' ? 'Add New' : 'Edit'} Board</h2>
+    </div>
+  );
+}

--- a/client/src/components/BoardDetailsModal.jsx
+++ b/client/src/components/BoardDetailsModal.jsx
@@ -35,6 +35,10 @@ export default function BoardDetailsModal() {
     );
   }
 
+  function deleteColumnName(id) {
+    setBoardColumns(boardColumns.filter(column => column.id !== id));
+  }
+
   return (
     <div>
       <FontAwesomeIcon icon={faXmark} onClick={() => setBoardDetails(null)} />
@@ -49,15 +53,21 @@ export default function BoardDetailsModal() {
         <label>
           Board Columns
           {boardColumns.map(column => (
-            <input
-              key={column.id}
-              type="text"
-              name="columnName"
-              value={column.columnName}
-              onChange={e =>
-                updateColumnName(column.id, 'columnName', e.target.value)
-              }
-            />
+            <div>
+              <input
+                key={column.id}
+                type="text"
+                name="columnName"
+                value={column.columnName}
+                onChange={e =>
+                  updateColumnName(column.id, 'columnName', e.target.value)
+                }
+              />
+              <FontAwesomeIcon
+                icon={faXmark}
+                onClick={() => deleteColumnName(column.id)}
+              />
+            </div>
           ))}
         </label>
 

--- a/client/src/components/MenuModal.jsx
+++ b/client/src/components/MenuModal.jsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom';
+
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faXmark } from '@fortawesome/free-solid-svg-icons';
+
+export default function MenuModal({ setDisplayMenuModal }) {
+  return (
+    <div>
+      <h3>All Boards</h3>
+      <FontAwesomeIcon
+        icon={faXmark}
+        onClick={() => setDisplayMenuModal(false)}
+      />
+
+      <Link>+ Create New Board</Link>
+      <Link to="/logout">Logout</Link>
+    </div>
+  );
+}

--- a/client/src/components/MenuModal.jsx
+++ b/client/src/components/MenuModal.jsx
@@ -3,7 +3,15 @@ import { Link } from 'react-router-dom';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default function MenuModal({ setDisplayMenuModal }) {
+export default function MenuModal({ setDisplayMenuModal, setBoardDetails }) {
+  function displayBoard(type) {
+    if (type === 'new') {
+      setBoardDetails('new');
+    }
+
+    setDisplayMenuModal(false);
+  }
+
   return (
     <div>
       <h3>All Boards</h3>
@@ -12,7 +20,7 @@ export default function MenuModal({ setDisplayMenuModal }) {
         onClick={() => setDisplayMenuModal(false)}
       />
 
-      <Link>+ Create New Board</Link>
+      <button onClick={() => displayBoard('new')}>+ Create New Board</button>
       <Link to="/logout">Logout</Link>
     </div>
   );

--- a/client/src/components/MenuModal.jsx
+++ b/client/src/components/MenuModal.jsx
@@ -1,20 +1,33 @@
+import { useContext } from 'react';
 import { Link } from 'react-router-dom';
+import { Context } from '../context/Context';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default function MenuModal({ setDisplayMenuModal, setBoardDetails }) {
+export default function MenuModal() {
+  const { setBoardDetails, setDisplayMenuModal, boards } = useContext(Context);
+
   function displayBoard(type) {
     if (type === 'new') {
       setBoardDetails('new');
     }
 
+    closeMenuModal();
+  }
+
+  function closeMenuModal() {
     setDisplayMenuModal(false);
   }
 
   return (
     <div>
-      <h3>All Boards</h3>
+      <h3>All Boards ({boards.length})</h3>
+      {boards?.map(board => (
+        <Link to={`/board/${board._id}`} onClick={closeMenuModal}>
+          {board.name}
+        </Link>
+      ))}
       <FontAwesomeIcon
         icon={faXmark}
         onClick={() => setDisplayMenuModal(false)}

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -5,15 +5,18 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 
 export default function Navbar() {
-  const { isLoggedIn, setDisplayMenuModal } = useContext(Context);
+  const { isLoggedIn, setDisplayMenuModal, setBoardDetails } =
+    useContext(Context);
+
+  function displayMenu() {
+    setBoardDetails(null);
+    setDisplayMenuModal(true);
+  }
 
   return (
     <nav>
       {isLoggedIn && (
-        <FontAwesomeIcon
-          icon={faEllipsisVertical}
-          onClick={() => setDisplayMenuModal(true)}
-        />
+        <FontAwesomeIcon icon={faEllipsisVertical} onClick={displayMenu} />
       )}
     </nav>
   );

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,9 +1,20 @@
 import { useContext } from 'react';
-import { Link } from 'react-router-dom';
 import { Context } from '../context/Context';
 
-export default function Navbar() {
-  const { isLoggedIn } = useContext(Context);
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faEllipsisVertical } from '@fortawesome/free-solid-svg-icons';
 
-  return <nav>{isLoggedIn && <Link to="/logout">Logout</Link>}</nav>;
+export default function Navbar() {
+  const { isLoggedIn, setDisplayMenuModal } = useContext(Context);
+
+  return (
+    <nav>
+      {isLoggedIn && (
+        <FontAwesomeIcon
+          icon={faEllipsisVertical}
+          onClick={() => setDisplayMenuModal(true)}
+        />
+      )}
+    </nav>
+  );
 }

--- a/client/src/context/Context.jsx
+++ b/client/src/context/Context.jsx
@@ -1,4 +1,5 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useEffect } from 'react';
+import axios from 'axios';
 
 const Context = createContext();
 
@@ -7,6 +8,7 @@ function ContextProvider(props) {
   const [authValue, setAuthValue] = useState(null);
   const [displayMenuModal, setDisplayMenuModal] = useState(false);
   const [boardDetails, setBoardDetails] = useState(null);
+  const [boards, setBoards] = useState([]);
 
   return (
     <Context.Provider
@@ -19,6 +21,8 @@ function ContextProvider(props) {
         setDisplayMenuModal,
         boardDetails,
         setBoardDetails,
+        boards,
+        setBoards,
       }}
     >
       {props.children}

--- a/client/src/context/Context.jsx
+++ b/client/src/context/Context.jsx
@@ -1,5 +1,4 @@
-import { createContext, useEffect, useState } from 'react';
-import axios from 'axios';
+import { createContext, useState } from 'react';
 
 const Context = createContext();
 

--- a/client/src/context/Context.jsx
+++ b/client/src/context/Context.jsx
@@ -6,10 +6,18 @@ const Context = createContext();
 function ContextProvider(props) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [authValue, setAuthValue] = useState(null);
+  const [displayMenuModal, setDisplayMenuModal] = useState(false);
 
   return (
     <Context.Provider
-      value={{ isLoggedIn, setIsLoggedIn, authValue, setAuthValue }}
+      value={{
+        isLoggedIn,
+        setIsLoggedIn,
+        authValue,
+        setAuthValue,
+        displayMenuModal,
+        setDisplayMenuModal,
+      }}
     >
       {props.children}
     </Context.Provider>

--- a/client/src/context/Context.jsx
+++ b/client/src/context/Context.jsx
@@ -6,6 +6,7 @@ function ContextProvider(props) {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [authValue, setAuthValue] = useState(null);
   const [displayMenuModal, setDisplayMenuModal] = useState(false);
+  const [boardDetails, setBoardDetails] = useState(null);
 
   return (
     <Context.Provider
@@ -16,6 +17,8 @@ function ContextProvider(props) {
         setAuthValue,
         displayMenuModal,
         setDisplayMenuModal,
+        boardDetails,
+        setBoardDetails,
       }}
     >
       {props.children}

--- a/client/src/pages/BoardPage.jsx
+++ b/client/src/pages/BoardPage.jsx
@@ -1,52 +1,36 @@
 import { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { Context } from '../context/Context';
-import MenuModal from '../components/MenuModal';
-import BoardDetailsModal from '../components/BoardDetailsModal';
+import Board from '../components/Board';
 
 export default function BoardPage() {
-  const {
-    setIsLoggedIn,
-    displayMenuModal,
-    setDisplayMenuModal,
-    boardDetails,
-    setBoardDetails,
-  } = useContext(Context);
+  const { setIsLoggedIn, setBoards } = useContext(Context);
 
   useEffect(() => {
-    async function checkAuthentication() {
+    async function getBoards() {
       try {
-        const res = await axios.get('/user', { withCredentials: true });
-        const { user } = res.data;
+        const res = await axios.get('/board/getBoards', {
+          withCredentials: true,
+        });
+
+        const { user, boards } = res.data;
 
         if (user) {
           setIsLoggedIn(true);
           localStorage.setItem('user', true);
+          setBoards(boards);
         }
       } catch (err) {
         console.error(err);
       }
     }
 
-    checkAuthentication();
+    getBoards();
   }, []);
 
   return (
     <main>
-      <h1>Platform Launch Board</h1>
-      {displayMenuModal && (
-        <MenuModal
-          setDisplayMenuModal={setDisplayMenuModal}
-          setBoardDetails={setBoardDetails}
-        />
-      )}
-      {boardDetails && (
-        <BoardDetailsModal
-          boardDetails={boardDetails}
-          setBoardDetails={setBoardDetails}
-          setDisplayMenuModal={setDisplayMenuModal}
-        />
-      )}
+      <Board />
     </main>
   );
 }

--- a/client/src/pages/BoardPage.jsx
+++ b/client/src/pages/BoardPage.jsx
@@ -1,9 +1,11 @@
 import { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { Context } from '../context/Context';
+import MenuModal from '../components/MenuModal';
 
 export default function BoardPage() {
-  const { setIsLoggedIn } = useContext(Context);
+  const { setIsLoggedIn, displayMenuModal, setDisplayMenuModal } =
+    useContext(Context);
 
   useEffect(() => {
     async function checkAuthentication() {
@@ -23,5 +25,12 @@ export default function BoardPage() {
     checkAuthentication();
   }, []);
 
-  return <h1>Platform Launch Board</h1>;
+  return (
+    <main>
+      <h1>Platform Launch Board</h1>
+      {displayMenuModal && (
+        <MenuModal setDisplayMenuModal={setDisplayMenuModal} />
+      )}
+    </main>
+  );
 }

--- a/client/src/pages/BoardPage.jsx
+++ b/client/src/pages/BoardPage.jsx
@@ -2,10 +2,16 @@ import { useEffect, useContext } from 'react';
 import axios from 'axios';
 import { Context } from '../context/Context';
 import MenuModal from '../components/MenuModal';
+import BoardDetailsModal from '../components/BoardDetailsModal';
 
 export default function BoardPage() {
-  const { setIsLoggedIn, displayMenuModal, setDisplayMenuModal } =
-    useContext(Context);
+  const {
+    setIsLoggedIn,
+    displayMenuModal,
+    setDisplayMenuModal,
+    boardDetails,
+    setBoardDetails,
+  } = useContext(Context);
 
   useEffect(() => {
     async function checkAuthentication() {
@@ -29,7 +35,17 @@ export default function BoardPage() {
     <main>
       <h1>Platform Launch Board</h1>
       {displayMenuModal && (
-        <MenuModal setDisplayMenuModal={setDisplayMenuModal} />
+        <MenuModal
+          setDisplayMenuModal={setDisplayMenuModal}
+          setBoardDetails={setBoardDetails}
+        />
+      )}
+      {boardDetails && (
+        <BoardDetailsModal
+          boardDetails={boardDetails}
+          setBoardDetails={setBoardDetails}
+          setDisplayMenuModal={setDisplayMenuModal}
+        />
       )}
     </main>
   );

--- a/server/controllers/board.js
+++ b/server/controllers/board.js
@@ -1,7 +1,21 @@
 const path = require('path');
+const Board = require('../models/Board');
 
 module.exports = {
   getIndex: (req, res) => {
     res.sendFile(path.join(__dirname, '../../client/dist', 'index.html'));
+  },
+  createBoard: async (req, res) => {
+    try {
+      await Board.create({
+        name: req.body.boardName,
+        columns: req.body.columnName,
+        userId: req.user.id,
+      });
+      console.log('Board has been added');
+      res.redirect('/board');
+    } catch (err) {
+      console.error(err);
+    }
   },
 };

--- a/server/controllers/board.js
+++ b/server/controllers/board.js
@@ -5,6 +5,16 @@ module.exports = {
   getIndex: (req, res) => {
     res.sendFile(path.join(__dirname, '../../client/dist', 'index.html'));
   },
+  getBoards: async (req, res) => {
+    console.log(req.user);
+
+    try {
+      const boards = await Board.find({ userId: req.user.id });
+      res.status(200).json({ boards: boards, user: req.user.id });
+    } catch (err) {
+      console.error(err);
+    }
+  },
   createBoard: async (req, res) => {
     try {
       await Board.create({

--- a/server/models/Board.js
+++ b/server/models/Board.js
@@ -1,0 +1,18 @@
+const mongoose = require('mongoose');
+
+const BoardSchema = new mongoose.Schema({
+  name: {
+    type: String,
+    required: true,
+  },
+  columns: {
+    type: Array,
+    required: true,
+  },
+  userId: {
+    type: String,
+    required: true,
+  },
+});
+
+module.exports = mongoose.model('Board', BoardSchema);

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -4,5 +4,6 @@ const boardController = require('../controllers/board');
 const { ensureAuth } = require('../middleware/auth');
 
 router.get('/', ensureAuth, boardController.getIndex);
+router.post('/createBoard', boardController.createBoard);
 
 module.exports = router;

--- a/server/routes/board.js
+++ b/server/routes/board.js
@@ -4,6 +4,7 @@ const boardController = require('../controllers/board');
 const { ensureAuth } = require('../middleware/auth');
 
 router.get('/', ensureAuth, boardController.getIndex);
+router.get('/getBoards', boardController.getBoards);
 router.post('/createBoard', boardController.createBoard);
 
 module.exports = router;


### PR DESCRIPTION
## Description
This PR introduces a new feature that allows users to create boards. They can define the board name and adjust the column names, including the predefined columns like 'Todo' and 'Doing'. I implemented dynamic column management by setting up a `boardColumns` state, allowing users to add or delete columns as needed. Once the form is submitted, the request gets sent to the `/board/createBoard` endpoint which stores the board details along with the `userId` of the authenticated user. I then updated the `getBoard` endpoint to fetch and return all boards associated with the logged-in user and store them into the application's context state `boards` for easy access throughout the app. The `MenuModal` component now generates links for each board based on its `_id`. Clicking it will dynamically render the `Board` component which will display the board details based on the selected board's `_id` which is extracted from the URL. I then utilized the `find()` method to locate the board with a matching `_id` in the `boards` array.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|   | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|  ✓   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |