### PR TITLE
Feat: Delete Board

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -98,6 +98,13 @@ export default function Board() {
           setDisplayTaskModal={setDisplayTaskModal}
         />
       )}
+      {displayTaskModal === 'deleteBoard' && (
+        <DeleteModal
+          board={board}
+          displayTaskModal={displayTaskModal}
+          setDisplayTaskModal={setDisplayTaskModal}
+        />
+      )}
       {viewTask && (
         <ViewTaskModal
           task={viewTask}

--- a/client/src/components/DeleteModal.jsx
+++ b/client/src/components/DeleteModal.jsx
@@ -6,11 +6,14 @@ export default function DeleteModal({
   displayTaskModal,
   setDisplayTaskModal,
 }) {
-  async function deleteTask() {
-    const taskId = selectedTask._id;
+  async function deleteData() {
+    const data =
+      displayTaskModal === 'deleteTask' ? selectedTask._id : board._id;
 
     try {
-      const res = await axios.delete('/board/delete', { data: { taskId } });
+      const res = await axios.delete('/board/delete', {
+        data: { displayTaskModal, data },
+      });
       console.log(res);
       setDisplayTaskModal(false);
     } catch (err) {
@@ -37,7 +40,7 @@ export default function DeleteModal({
             : ' '
         }cannot be reversed.`}
       </p>
-      <button onClick={() => deleteTask()}>Delete</button>
+      <button onClick={() => deleteData()}>Delete</button>
       <button onClick={() => setDisplayTaskModal(false)}>Cancel</button>
     </div>
   );

--- a/client/src/components/DeleteModal.jsx
+++ b/client/src/components/DeleteModal.jsx
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 export default function DeleteModal({
+  board,
   selectedTask,
   displayTaskModal,
   setDisplayTaskModal,
@@ -19,10 +20,22 @@ export default function DeleteModal({
 
   return (
     <div>
-      <h2>Delete this task?</h2>
+      <h2>
+        Delete this {`${displayTaskModal === 'deleteTask' ? 'task' : 'board'}`}?
+      </h2>
       <p>
-        Are you sure you want to delete the {`'${selectedTask.title}'`} task and
-        its subtasks? This action cannot be reversed.
+        Are you sure you want to delete the
+        {`${
+          displayTaskModal === 'deleteTask'
+            ? ` '${selectedTask.title}' task and its subtasks`
+            : ` '${board.name}' board`
+        }`}
+        ?{' '}
+        {`This action ${
+          displayTaskModal === 'deleteBoard'
+            ? 'will remove all columns and tasks and '
+            : ' '
+        }cannot be reversed.`}
       </p>
       <button onClick={() => deleteTask()}>Delete</button>
       <button onClick={() => setDisplayTaskModal(false)}>Cancel</button>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
 import { Context } from '../context/Context';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -11,6 +11,8 @@ export default function Navbar() {
     setBoardDetails,
     setDisplayTaskModal,
   } = useContext(Context);
+
+  const [displaySettings, setDisplaySettings] = useState(false);
 
   function displayMenu() {
     setBoardDetails(null);
@@ -30,8 +32,17 @@ export default function Navbar() {
         <span>
           <h2 onClick={displayMenu}>Boards</h2>
           <FontAwesomeIcon icon={faPlus} onClick={displayTask} />
-          <FontAwesomeIcon icon={faEllipsisVertical} />
+          <FontAwesomeIcon
+            icon={faEllipsisVertical}
+            onClick={() => setDisplaySettings(true)}
+          />
         </span>
+      )}
+
+      {displaySettings && (
+        <div>
+          <button>Delete Board</button>
+        </div>
       )}
     </nav>
   );

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -41,7 +41,9 @@ export default function Navbar() {
 
       {displaySettings && (
         <div>
-          <button>Delete Board</button>
+          <button onClick={() => setDisplayTaskModal('deleteBoard')}>
+            Delete Board
+          </button>
         </div>
       )}
     </nav>

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -28,8 +28,9 @@ export default function Navbar() {
     <nav>
       {isLoggedIn && (
         <span>
+          <h2 onClick={displayMenu}>Boards</h2>
           <FontAwesomeIcon icon={faPlus} onClick={displayTask} />
-          <FontAwesomeIcon icon={faEllipsisVertical} onClick={displayMenu} />
+          <FontAwesomeIcon icon={faEllipsisVertical} />
         </span>
       )}
     </nav>

--- a/server/controllers/board.js
+++ b/server/controllers/board.js
@@ -111,10 +111,17 @@ module.exports = {
     }
   },
   delete: async (req, res) => {
+    console.log(req.body);
     try {
-      await Task.deleteOne({ _id: req.body.taskId });
-      console.log('Task has been deleted');
-      res.status(200).json('Task has been deleted');
+      if (req.body.displayTaskModal === 'deleteTask') {
+        await Task.deleteOne({ _id: req.body.data });
+        console.log('Task has been deleted');
+        res.status(200).json('Task has been deleted');
+      } else {
+        await Board.deleteOne({ _id: req.body.data });
+        console.log('Board has been deleted');
+        res.status(200).json('Board has been deleted');
+      }
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Description
This PR implements a new feature allowing users to delete an entire board. This includes a refactoring of the existing code within the `DeleteModal` component to dynamically customize the deletion message based on the item (task or board) to be deleted. Based on the value of the `displayTaskModal` state, the `deleteData()` function has been modified to handle both task and board deletions. The function first checks the value of `displayTaskModal`, if it equals `'deleteTask'`, it sets the `data` variable to the id of the specific task to be deleted, otherwise it assumes the user wants to delete the entire board and the `data` variable is set to the id of the board. The Axios DELETE request now sends an object containing `displayTaskModal` and `data` as data parameters to help the server determine which item (task or board) to delete. 

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|   | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|  ✓  | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |