### PR TITLE
Feat: '+ New Column' Card for Board Column Addition

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -82,7 +82,7 @@ export default function Board() {
               </div>
             )}
             {board.columns.length > 0 && (
-              <div className="hidden text-mediumGrey bg-column text-lg font-semibold min-w-[280px] h-[814px] lg:flex justify-center items-center gap-1 rounded-md mt-10">
+              <div className="hidden text-mediumGrey bg-column text-lg font-semibold min-w-[280px] h-[814px] lg:flex justify-center items-center gap-1 rounded-md mt-10 cursor-pointer hover:text-mainPurple">
                 <FontAwesomeIcon icon={faPlus} className="text-xs" />
                 New Column
               </div>

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -82,7 +82,10 @@ export default function Board() {
               </div>
             )}
             {board.columns.length > 0 && (
-              <div className="hidden text-mediumGrey bg-column text-lg font-semibold min-w-[280px] h-[814px] lg:flex justify-center items-center gap-1 rounded-md mt-10 cursor-pointer hover:text-mainPurple">
+              <div
+                onClick={() => openModal('editBoard')}
+                className="hidden text-mediumGrey bg-column text-lg font-semibold min-w-[280px] h-[814px] lg:flex justify-center items-center gap-1 rounded-md mt-10 cursor-pointer hover:text-mainPurple"
+              >
                 <FontAwesomeIcon icon={faPlus} className="text-xs" />
                 New Column
               </div>

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -81,6 +81,12 @@ export default function Board() {
                 </button>
               </div>
             )}
+            {board.columns.length > 0 && (
+              <div className="hidden text-mediumGrey bg-column text-lg font-semibold min-w-[280px] h-[814px] lg:flex justify-center items-center gap-1 rounded-md mt-10">
+                <FontAwesomeIcon icon={faPlus} className="text-xs" />
+                New Column
+              </div>
+            )}
           </section>
         )}
 

--- a/client/src/components/Column.jsx
+++ b/client/src/components/Column.jsx
@@ -13,7 +13,7 @@ export default function Column({
   const columnTasks = tasks?.filter(task => task.status === name);
 
   return (
-    <section className="pr-4">
+    <section className="min-w-[280px] pr-4">
       <div className="flex gap-3">
         <FontAwesomeIcon icon={faCircle} className="w-[15px] h-[15px]" />
         <h3 className="text-mediumGrey text-xs font-medium uppercase tracking-widest mb-6">{`${name} (${

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -13,6 +13,7 @@ export default {
         mainPurpleHover: '#A8A4FF',
         redHover: '#FF9898',
         linesDark: '#3E3F4E',
+        column: 'rgba(43, 44, 55, 0.13)',
       },
       fontFamily: {
         body: ['Plus Jakarta Sans'],


### PR DESCRIPTION
## Description
This PR enhances the user interface by displaying a '+ New Column' card beside the last board column, visible only on screen sizes equal to or greater than 1024px. By clicking it, the BoardDetails modal opens, allowing users to add more columns to the board.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  | :bug: Bug fix              |
|  ✓  | :sparkles: New feature     |
|   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |