### PR TITLE
Fix: Resolve Board State Loss Issue When Refreshing

### DIFF
--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -24,6 +24,7 @@ export default function Board() {
     setDisplaySettings,
     displaySidebar,
     setDisplaySidebar,
+    setBoards,
   } = useContext(Context);
   const { id } = useParams();
 
@@ -33,20 +34,27 @@ export default function Board() {
 
   useEffect(() => {
     if (id) {
-      async function getBoardData() {
+      async function fetchData() {
         try {
-          const res = await axios.get(`/api/board/${id}`, {
-            withCredentials: true,
-          });
+          const [boardRes, boardsRes] = await Promise.all([
+            axios.get(`/api/board/${id}`, {
+              withCredentials: true,
+            }),
+            axios.get('/api/board/getBoards', {
+              withCredentials: true,
+            }),
+          ]);
 
-          const { board, tasks } = res.data;
+          const { board, tasks } = boardRes.data;
+          const { boards } = boardsRes.data;
           setBoard(board[0]);
           setTasks(tasks);
+          setBoards(boards);
         } catch (err) {
           console.error(err);
         }
       }
-      getBoardData();
+      fetchData();
     }
   }, [id]);
 


### PR DESCRIPTION
## Description
This PR resolves a critical issue where the application encountered state loss when users refreshed the page on any specific board on `/board/${id}` path. The root cause was the inability to fetch the necessary data after the state was lost. To mitigate this, I've refactored the `useEffect()` function to `fetchData()` to handle parallel requests to both `/board/${id}` and `/board/getBoards` endpoints using `Promise.all()`. Then utilized `setBoards` to store all user boards, ensuring the prevention of state loss on refresh.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |