### PR TITLE
Feat: Improve Board Deletion Behaviour and Navigation

### DIFF
--- a/client/src/components/Delete.jsx
+++ b/client/src/components/Delete.jsx
@@ -1,7 +1,13 @@
+import { useContext } from 'react';
+import { Context } from '../context/Context';
+import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import Modal from './Modal';
 
 export default function Delete({ board, selectedTask, modal, closeModal }) {
+  const { boards } = useContext(Context);
+  const navigate = useNavigate();
+
   async function deleteData() {
     const data = modal === 'deleteTask' ? selectedTask._id : board._id;
 
@@ -10,7 +16,13 @@ export default function Delete({ board, selectedTask, modal, closeModal }) {
         data: { modal, data },
       });
       console.log(res);
-      window.location.reload();
+
+      if (modal === 'deleteTask') {
+        window.location.reload();
+      } else {
+        navigate(`/board/${boards[boards.length - 2]._id}`);
+      }
+      closeModal();
     } catch (err) {
       console.error(err);
     }

--- a/client/src/components/Delete.jsx
+++ b/client/src/components/Delete.jsx
@@ -20,7 +20,10 @@ export default function Delete({ board, selectedTask, modal, closeModal }) {
       if (modal === 'deleteTask') {
         window.location.reload();
       } else {
-        navigate(`/board/${boards[boards.length - 2]._id}`);
+        const previousBoard =
+          boards.findIndex(elem => elem._id === board._id) - 1;
+
+        navigate(`/board/${boards[previousBoard]._id}`);
       }
       closeModal();
     } catch (err) {


### PR DESCRIPTION
## Description
This PR corrects the behaviour when deleting a board. Previously, after deleting a board, the page would reload but it remained on the deleted board's path, displaying nothing on the screen. I corrected it to now navigate to the board previous to the one deleted, ensuring relevant data is always shown after a board deletion.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  | :bug: Bug fix              |
| ✓   | :sparkles: New feature     |
|   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |