### PR TITLE
Feat: Seamless Board Updates without Page Refresh

### DIFF
--- a/client/src/components/AddTask.jsx
+++ b/client/src/components/AddTask.jsx
@@ -6,7 +6,12 @@ import Modal from './Modal';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-export default function AddTask({ id, columns, closeModal }) {
+export default function AddTask({
+  id,
+  columns,
+  setIsBoardUpdated,
+  closeModal,
+}) {
   const navigate = useNavigate();
 
   const [titleInputTouched, setTitleInputTouched] = useState(false);
@@ -94,8 +99,8 @@ export default function AddTask({ id, columns, closeModal }) {
       });
       console.log(res);
       if (res.status === 200) {
+        setIsBoardUpdated(true);
         closeModal();
-        navigate(0);
       }
     } catch (err) {
       console.error(err);

--- a/client/src/components/AddTask.jsx
+++ b/client/src/components/AddTask.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import Modal from './Modal';
 
@@ -12,8 +11,6 @@ export default function AddTask({
   setIsBoardUpdated,
   closeModal,
 }) {
-  const navigate = useNavigate();
-
   const [titleInputTouched, setTitleInputTouched] = useState(false);
 
   const [subtasks, setSubtasks] = useState([

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -144,6 +144,7 @@ export default function Board() {
             id={board._id}
             columns={board.columns}
             closeModal={closeModal}
+            setIsBoardUpdated={setIsBoardUpdated}
           />
         )}
         {modal === 'viewTask' && (

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -135,7 +135,9 @@ export default function Board() {
         )}
 
         {modal === 'menu' && <Menu />}
-        {modal === 'editBoard' && <BoardDetails board={board} />}
+        {modal === 'editBoard' && (
+          <BoardDetails board={board} setIsBoardUpdated={setIsBoardUpdated} />
+        )}
         {modal === 'new' && <BoardDetails board={board} />}
         {modal === 'add' && (
           <AddTask

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -162,6 +162,7 @@ export default function Board() {
             id={board._id}
             selectedTask={viewTask}
             columns={board.columns}
+            setIsBoardUpdated={setIsBoardUpdated}
             closeModal={closeModal}
           />
         )}

--- a/client/src/components/Board.jsx
+++ b/client/src/components/Board.jsx
@@ -32,6 +32,7 @@ export default function Board() {
   const [tasks, setTasks] = useState();
   const [viewTask, setViewTask] = useState();
   const [selectedStatus, setSelectedStatus] = useState();
+  const [isBoardUpdated, setIsBoardUpdated] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -51,13 +52,14 @@ export default function Board() {
           setBoard(board[0]);
           setTasks(tasks);
           setBoards(boards);
+          setIsBoardUpdated(false);
         } catch (err) {
           console.error(err);
         }
       }
       fetchData();
     }
-  }, [id]);
+  }, [id, isBoardUpdated]);
 
   return (
     <section className="w-screen h-screen flex">
@@ -147,6 +149,7 @@ export default function Board() {
             task={viewTask}
             columns={board.columns}
             selectedStatus={selectedStatus}
+            setIsBoardUpdated={setIsBoardUpdated}
             openModal={openModal}
             closeModal={closeModal}
           />

--- a/client/src/components/BoardDetails.jsx
+++ b/client/src/components/BoardDetails.jsx
@@ -7,7 +7,7 @@ import Modal from './Modal';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 
-export default function BoardDetails({ board }) {
+export default function BoardDetails({ board, setIsBoardUpdated }) {
   const navigate = useNavigate();
   const { modal, closeModal } = useContext(Context);
 
@@ -104,8 +104,8 @@ export default function BoardDetails({ board }) {
         const res = await axios.put('/api/board/editBoard', { boardData });
 
         if (res.status === 200) {
+          setIsBoardUpdated(true);
           closeModal();
-          window.location.reload();
         }
       }
     } catch (err) {

--- a/client/src/components/EditTask.jsx
+++ b/client/src/components/EditTask.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import Modal from './Modal';
 
@@ -13,8 +12,6 @@ export default function EditTask({
   setIsBoardUpdated,
   closeModal,
 }) {
-  const navigate = useNavigate();
-
   const [task, setTask] = useState(selectedTask);
   const [subtasks, setSubtasks] = useState(task.subtasks);
   const [titleInputTouched, setTitleInputTouched] = useState(false);

--- a/client/src/components/EditTask.jsx
+++ b/client/src/components/EditTask.jsx
@@ -6,7 +6,13 @@ import Modal from './Modal';
 import { faXmark } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
-export default function EditTask({ id, selectedTask, columns, closeModal }) {
+export default function EditTask({
+  id,
+  selectedTask,
+  columns,
+  setIsBoardUpdated,
+  closeModal,
+}) {
   const navigate = useNavigate();
 
   const [task, setTask] = useState(selectedTask);
@@ -84,8 +90,8 @@ export default function EditTask({ id, selectedTask, columns, closeModal }) {
       });
       console.log(res);
       if (res.status === 200) {
+        setIsBoardUpdated(true);
         closeModal();
-        navigate(0);
       }
     } catch (err) {
       console.error(err);

--- a/client/src/components/ViewTask.jsx
+++ b/client/src/components/ViewTask.jsx
@@ -1,4 +1,3 @@
-import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { useState } from 'react';
 import Modal from './Modal';
@@ -21,7 +20,6 @@ export default function ViewTask({
   const [subtasks, setSubtasks] = useState(task.subtasks);
   const [settingsModal, setSettingsModal] = useState(false);
 
-  const navigate = useNavigate();
   const completedSubtasks = task.subtasks.filter(
     task => task.completed === true
   ).length;

--- a/client/src/components/ViewTask.jsx
+++ b/client/src/components/ViewTask.jsx
@@ -49,7 +49,6 @@ export default function ViewTask({
         completed: completed,
       });
       console.log(res);
-      // navigate(0);
     } catch (err) {
       console.error(err);
     }

--- a/client/src/components/ViewTask.jsx
+++ b/client/src/components/ViewTask.jsx
@@ -60,8 +60,8 @@ export default function ViewTask({
         taskId: task._id,
         status: newStatus,
       });
+      setIsBoardUpdated(true);
       console.log(res);
-      navigate(0);
     } catch (err) {
       console.error(err);
     }

--- a/client/src/components/ViewTask.jsx
+++ b/client/src/components/ViewTask.jsx
@@ -14,6 +14,7 @@ export default function ViewTask({
   task,
   columns,
   selectedStatus,
+  setIsBoardUpdated,
   openModal,
   closeModal,
 }) {
@@ -40,6 +41,7 @@ export default function ViewTask({
       });
 
       setSubtasks(updatedSubtasks);
+      setIsBoardUpdated(true);
 
       const res = await axios.put('/api/board/setCompletionStatus', {
         taskId: task._id,
@@ -47,7 +49,7 @@ export default function ViewTask({
         completed: completed,
       });
       console.log(res);
-      navigate(0);
+      // navigate(0);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## Description
This PR optimizes the user experience by reducing any unnecessary page refreshes by introducing a new state `isBoardUpdated`, designed to track any changes that require the board to be updated. I modified the logic within tasks-related operations (adding a new task, editing a task, changing subtask completion or task status) and editing the board, to then update the `isBoardUpdated` state to `true`. This ensures the changes are seamlessly tracked, and the latest data is efficiently fetched without resorting to a manual page reload. These optimizations result in a smoother and more responsive user experience, reflecting the most up-to-date board information.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|   | :bug: Bug fix              |
| ✓  | :sparkles: New feature     |
|   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |