### PR TITLE
Fix: Improved Board Deletion and Navigation

### DIFF
--- a/client/src/components/Delete.jsx
+++ b/client/src/components/Delete.jsx
@@ -29,8 +29,12 @@ export default function Delete({
         const previousBoard =
           boards?.findIndex(elem => elem._id === board._id) - 1;
 
-        if (boards.length !== 1) {
+        const deletedFirstBoard = boards[0]._id === board._id;
+
+        if (boards.length !== 1 && !deletedFirstBoard) {
           navigate(`/board/${boards[previousBoard]._id}`);
+        } else if (boards.length !== 1 && deletedFirstBoard) {
+          navigate(`/board/${boards[1]._id}`);
         } else {
           navigate('/board');
           window.location.reload();


### PR DESCRIPTION
## Description
This PR corrects a behaviour issue when deleting the first board when multiple boards exist. Previously, the board would get deleted but nothing else would happen. I enhanced the board navigation logic, if the deleted board is not the first and there are multiple boards, it navigates to the previous board. If the deleted board is the first, it navigates to the second board if available; otherwise, it reloads the board page, displaying the prompt to create a new board.

## Type of Changes
|     | Type                       |
| --- | -------------------------- |
|  ✓ | :bug: Bug fix              |
|   | :sparkles: New feature     |
|   | :hammer: Refactoring       |
|     | :100: Add tests            |
|     | :link: Update dependencies |
|     | :scroll: Docs              |